### PR TITLE
for each gkyl frame, load it once and run xpt finder

### DIFF
--- a/XPointMLTest.py
+++ b/XPointMLTest.py
@@ -57,12 +57,23 @@ class XPointDataset(Dataset):
         self.outDir = "plots"
         os.makedirs(self.outDir, exist_ok=True)
 
+        # load all the data
+        self.data = []
+        for fnum in fnumList:
+            print("fnum " + str(fnum))
+            self.data.append(self.load(fnum))
+
     def __len__(self):
         return len(self.fnumList)
 
     def __getitem__(self, idx):
         t0 = timer()
         fnum = self.fnumList[idx]
+        print(f"[XPointDataset] Fetching fileNum = {fnum}")
+        return self.data[idx]
+
+    def load(self, fnum):
+        t0 = timer()
         print(f"[XPointDataset] Processing fileNum = {fnum}")
 
         # Initialize gkData object
@@ -150,6 +161,8 @@ class XPointDataset(Dataset):
             "filenameBase": tmp.filenameBase, 
             "params": dict(self.params)  # copy of the params for local plotting
         }
+
+
 
 # 2) U-NET ARCHITECTURE
 class UNet(nn.Module):

--- a/XPointMLTest.py
+++ b/XPointMLTest.py
@@ -355,13 +355,13 @@ def main():
 
     # Evaluate on combined set for demonstration. Exam this part to see if save to remove
     full_fnums = list(train_fnums) + list(val_fnums)
-    full_dataset = XPointDataset(paramFile, full_fnums, constructJz=1, interpFac=interpFac, saveFig=1)  
+    full_dataset = [train_dataset, val_dataset]
 
     t4 = timer()
-    print("time (s) to create gkyl data loader: " + str(t4-t3))
 
     with torch.no_grad():
-        for item in full_dataset:
+      for set in full_dataset:
+        for item in set:
             # item is a dict with keys: fnum, psi, mask, psi_np, mask_np, x, y, tmp, params
             fnum     = item["fnum"]
             psi_np   = item["psi_np"]

--- a/XPointMLTest.py
+++ b/XPointMLTest.py
@@ -67,7 +67,6 @@ class XPointDataset(Dataset):
         return len(self.fnumList)
 
     def __getitem__(self, idx):
-        t0 = timer()
         fnum = self.fnumList[idx]
         print(f"[XPointDataset] Fetching fileNum = {fnum}")
         return self.data[idx]
@@ -411,6 +410,7 @@ def main():
 
     t5 = timer()
     print("time (s) to apply model: " + str(t5-t4))
+    print("total time (s): " + str(t5-t0))
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This PR has changes to, for each frame of gkyl data, read the data from disk and run the x-point finder on it exactly one time. Prior to this commit, each time a batch was accessed in the \'for batch in loader\' loop of \'train_one_epoch\' the gkyl data was read from disk and the xpoint finder run.  Likewise, a 'full' dataset was being created that loaded all the data again.  That was removed and re-uses the training and validation data that was read at the start of the script.

With this change the GPU usage is over 95% when in the training loop (screenshot attached) and training completes in 102 seconds.

```
time (s) to train model: 102.34333014301956
```

![2025-03-08-143148_3819x837_scrot](https://github.com/user-attachments/assets/eb4a31a8-43a6-484a-8227-ec0e789e8454)

Total execution time is now about 6 minutes on checkers.

`total time (s): 372.5943310050061`


