### PR TITLE
rotate and reflect frames

### DIFF
--- a/XPointMLTest.py
+++ b/XPointMLTest.py
@@ -118,9 +118,6 @@ class XPointDataset(Dataset):
         self.params["symBar"]       = 1
         self.params["colormap"]     = 'bwr'
 
-        # output directory:
-        self.outDir = "plots"
-        os.makedirs(self.outDir, exist_ok=True)
 
         # load all the data
         self.data = []
@@ -626,6 +623,8 @@ def parseCommandLineArgs():
             ''')
     parser.add_argument('--plot', type=bool, default=False,
             help='create figures of the ground truth X-points and model identified X-points')
+    parser.add_argument('--plotDir', type=Path, default="./plots",
+            help='directory where figures are written')
     args = parser.parse_args()
     return args
 
@@ -665,6 +664,10 @@ def checkCommandLineArgs(args):
 def main():
     args = parseCommandLineArgs()
     checkCommandLineArgs(args)
+
+    # output directory:
+    outDir = args.plotDir
+    os.makedirs(outDir, exist_ok=True)
 
     t0 = timer()
     train_fnums = range(args.trainFrameFirst, args.trainFrameLast)
@@ -710,8 +713,7 @@ def main():
 
     # (D) Plotting after training
     model.eval() 
-    outDir = "output_images"
-    os.makedirs(outDir, exist_ok=True)
+    outDir = "plots"
     interpFac = 1  
 
     # Evaluate on combined set for demonstration. Exam this part to see if save to remove

--- a/XPointMLTest.py
+++ b/XPointMLTest.py
@@ -106,7 +106,7 @@ class XPointDataset(Dataset):
       - Returns (psiTensor, maskTensor) as a PyTorch (float) pair.
     """
     def __init__(self, paramFile, fnumList, constructJz=1, interpFac=1,
-            saveFig=1, xptCacheDir=None):
+            saveFig=1, xptCacheDir=None, rotateAndReflect=False):
         """
         paramFile:   Path to parameter file (string).
         fnumList:    List of frames to iterate. 
@@ -143,11 +143,12 @@ class XPointDataset(Dataset):
         for fnum in fnumList:
             frameData = self.load(fnum)
             self.data.append(frameData)
-            self.data.append(rotate(frameData,90))
-            self.data.append(rotate(frameData,180))
-            self.data.append(rotate(frameData,270))
-            self.data.append(reflect(frameData,0))
-            self.data.append(reflect(frameData,1))
+            if rotateAndReflect:
+              self.data.append(rotate(frameData,90))
+              self.data.append(rotate(frameData,180))
+              self.data.append(rotate(frameData,270))
+              self.data.append(reflect(frameData,0))
+              self.data.append(reflect(frameData,1))
 
     def __len__(self):
         return len(self.data)
@@ -698,7 +699,8 @@ def main():
     val_fnums   = range(args.validationFrameFirst, args.validationFrameLast)
 
     train_dataset = XPointDataset(args.paramFile, train_fnums, constructJz=1,
-            interpFac=1, saveFig=1, xptCacheDir=args.xptCacheDir)
+            interpFac=1, saveFig=1, xptCacheDir=args.xptCacheDir,
+            rotateAndReflect=True)
     val_dataset   = XPointDataset(args.paramFile, val_fnums,   constructJz=1,
             interpFac=1, saveFig=1, xptCacheDir=args.xptCacheDir)
 

--- a/XPointMLTest.py
+++ b/XPointMLTest.py
@@ -57,6 +57,19 @@ def expand_xpoints_mask(binary_mask, kernel_size=9):
     
     return expanded_mask
 
+def rotate(frameData,deg):
+    if deg not in [90, 180, 270]:
+        print(f"invalid rotation specified... exiting")
+        sys.exit()
+    psi = frameData["psi"]
+    shape = psi.shape
+    if shape[1] != shape[2]:
+        print(f"input data must be square... exiting")
+        sys.exit()
+    frameData["psi"] = np.rot90(frameData["psi"][0], deg/90).reshape(shape)
+    frameData["mask"] = np.rot90(frameData["mask"][0], deg/90).reshape(shape)
+    return frameData
+
 
 # DATASET DEFINITION
 class XPointDataset(Dataset):
@@ -107,7 +120,13 @@ class XPointDataset(Dataset):
         # load all the data
         self.data = []
         for fnum in fnumList:
-            self.data.append(self.load(fnum))
+            frameData = self.load(fnum)
+            self.data.append(frameData)
+            self.data.append(rotate(frameData,90))
+#            self.data.append(rotate(frameData,180))
+#            self.data.append(rotate(frameData,270))
+#            self.data.append(reflect(frameData,0))
+#            self.data.append(reflect(frameData,1))
 
     def __len__(self):
         return len(self.fnumList)

--- a/XPointMLTest.py
+++ b/XPointMLTest.py
@@ -568,7 +568,7 @@ def plot_model_performance(psi_np, pred_prob_np, mask_gt, x, y, params, fnum, fi
     
     plt.close()
 
-def plot_training_history(train_losses, val_losses, save_path='output_images/training_history.png'):
+def plot_training_history(train_losses, val_losses, save_path='plots/training_history.png'):
     """
     Plots training and validation losses across epochs.
     


### PR DESCRIPTION
This PR adds rotated and reflected frames to the training sets.
The current rotations are 90, 180 and 270 degrees and reflections are about the x and y axis.

No frames are currently being added that are **both** rotated and reflected (e.g., rotate by 90 then reflect about y axis).  If more frames are needed this can be added.

A few other minor changes include:
- only writing figures to the './plots' directory (or the user specified dir via `--plotDir`)
- disable writing figures by default, `--plot True` will enable them
- modified figure file names to include reflection and rotation info