### PR TITLE
fixes in rotate and reflect functions

### DIFF
--- a/XPointMLTest.py
+++ b/XPointMLTest.py
@@ -861,9 +861,6 @@ def main():
     t2 = timer()
     print("time (s) to prepare model: " + str(t2-t1))
 
-    train_loss = []
-    val_loss = []
-
     num_epochs = args.epochs
     for epoch in range(start_epoch, num_epochs):
         train_loss.append(train_one_epoch(model, train_loader, criterion, optimizer, device))

--- a/XPointMLTest.py
+++ b/XPointMLTest.py
@@ -59,12 +59,24 @@ def expand_xpoints_mask(binary_mask, kernel_size=9):
     
     return expanded_mask
 
+def plotSimple(arr, outfile):
+    plt.imshow(arr, interpolation="nearest", origin="upper")
+    plt.colorbar()
+    plt.savefig(outfile)
+    plt.clf()
+
 def rotate(frameData,deg):
     if deg not in [90, 180, 270]:
         print(f"invalid rotation specified... exiting")
         sys.exit()
     psi = v2.functional.rotate(frameData["psi"], deg, v2.InterpolationMode.BILINEAR)
     all = v2.functional.rotate(frameData["all"], deg, v2.InterpolationMode.BILINEAR)
+
+    plotSimple(all[0], f"{frameData['fnum']}_rotation{deg}_all0.png")
+    plotSimple(all[1], f"{frameData['fnum']}_rotation{deg}_all1.png")
+    plotSimple(all[2], f"{frameData['fnum']}_rotation{deg}_all2.png")
+    plotSimple(all[3], f"{frameData['fnum']}_rotation{deg}_all3.png")
+    
     mask = v2.functional.rotate(frameData["mask"], deg, v2.InterpolationMode.BILINEAR)
     return {
         "fnum": frameData["fnum"],
@@ -85,6 +97,10 @@ def reflect(frameData,axis):
         sys.exit()
     psi = torch.flip(frameData["psi"][0], dims=(axis,)).unsqueeze(0)
     all = torch.flip(frameData["all"], dims=(axis,))
+    plotSimple(all[0], f"{frameData['fnum']}_reflectionAxis{axis}_all0.png")
+    plotSimple(all[1], f"{frameData['fnum']}_reflectionAxis{axis}_all1.png")
+    plotSimple(all[2], f"{frameData['fnum']}_reflectionAxis{axis}_all2.png")
+    plotSimple(all[3], f"{frameData['fnum']}_reflectionAxis{axis}_all3.png")
     mask = torch.flip(frameData["mask"][0], dims=(axis,)).unsqueeze(0)
     return {
         "fnum": frameData["fnum"],
@@ -258,6 +274,10 @@ class XPointDataset(Dataset):
         by_torch = torch.from_numpy(fields["By"]).float().unsqueeze(0)
         jz_torch = torch.from_numpy(fields["Jz"]).float().unsqueeze(0)
         all_torch = torch.cat((psi_torch,bx_torch,by_torch,jz_torch)) # [4, Nx, Ny]
+        plotSimple(all_torch[0], f"{fnum}_all0.png")
+        plotSimple(all_torch[1], f"{fnum}_all1.png")
+        plotSimple(all_torch[2], f"{fnum}_all2.png")
+        plotSimple(all_torch[3], f"{fnum}_all3.png")
         mask_torch = torch.from_numpy(binaryMap).float().unsqueeze(0)  # [1, Nx, Ny]
 
         if self.verbosity > 0:

--- a/XPointMLTest.py
+++ b/XPointMLTest.py
@@ -59,25 +59,16 @@ def expand_xpoints_mask(binary_mask, kernel_size=9):
     
     return expanded_mask
 
-def plotSimple(arr, outfile):
-    plt.imshow(arr, interpolation="nearest", origin="upper")
-    plt.colorbar()
-    plt.savefig(outfile)
-    plt.clf()
-
 def rotate(frameData,deg):
     if deg not in [90, 180, 270]:
         print(f"invalid rotation specified... exiting")
         sys.exit()
+        
     psi = v2.functional.rotate(frameData["psi"], deg, v2.InterpolationMode.BILINEAR)
     all = v2.functional.rotate(frameData["all"], deg, v2.InterpolationMode.BILINEAR)
-
-    plotSimple(all[0], f"{frameData['fnum']}_rotation{deg}_all0.png")
-    plotSimple(all[1], f"{frameData['fnum']}_rotation{deg}_all1.png")
-    plotSimple(all[2], f"{frameData['fnum']}_rotation{deg}_all2.png")
-    plotSimple(all[3], f"{frameData['fnum']}_rotation{deg}_all3.png")
-    
+    # For mask, use nearest neighbor interpolation to preserve binary values
     mask = v2.functional.rotate(frameData["mask"], deg, v2.InterpolationMode.NEAREST)
+    
     return {
         "fnum": frameData["fnum"],
         "rotation": deg,
@@ -99,12 +90,6 @@ def reflect(frameData,axis):
     psi = torch.flip(frameData["psi"], dims=(axis+1,))
     all = torch.flip(frameData["all"], dims=(axis+1,))
     mask = torch.flip(frameData["mask"], dims=(axis+1,))
-    
-    plotSimple(all[0], f"{frameData['fnum']}_reflectionAxis{axis}_all0.png")
-    plotSimple(all[1], f"{frameData['fnum']}_reflectionAxis{axis}_all1.png")
-    plotSimple(all[2], f"{frameData['fnum']}_reflectionAxis{axis}_all2.png")
-    plotSimple(all[3], f"{frameData['fnum']}_reflectionAxis{axis}_all3.png")
-    
     
     return {
         "fnum": frameData["fnum"],
@@ -278,10 +263,6 @@ class XPointDataset(Dataset):
         by_torch = torch.from_numpy(fields["By"]).float().unsqueeze(0)
         jz_torch = torch.from_numpy(fields["Jz"]).float().unsqueeze(0)
         all_torch = torch.cat((psi_torch,bx_torch,by_torch,jz_torch)) # [4, Nx, Ny]
-        plotSimple(all_torch[0], f"{fnum}_all0.png")
-        plotSimple(all_torch[1], f"{fnum}_all1.png")
-        plotSimple(all_torch[2], f"{fnum}_all2.png")
-        plotSimple(all_torch[3], f"{fnum}_all3.png")
         mask_torch = torch.from_numpy(binaryMap).float().unsqueeze(0)  # [1, Nx, Ny]
 
         if self.verbosity > 0:

--- a/XPointMLTest.py
+++ b/XPointMLTest.py
@@ -77,7 +77,6 @@ def rotate(frameData,deg):
     plotSimple(all[2], f"{frameData['fnum']}_rotation{deg}_all2.png")
     plotSimple(all[3], f"{frameData['fnum']}_rotation{deg}_all3.png")
     
-    # mask = v2.functional.rotate(frameData["mask"], deg, v2.InterpolationMode.BILINEAR)
     mask = v2.functional.rotate(frameData["mask"], deg, v2.InterpolationMode.NEAREST)
     return {
         "fnum": frameData["fnum"],
@@ -96,11 +95,7 @@ def reflect(frameData,axis):
     if axis not in [0,1]:
         print(f"invalid reflection axis specified... exiting")
         sys.exit()
-        
-    # psi = torch.flip(frameData["psi"][0], dims=(axis,)).unsqueeze(0)
-    # all = torch.flip(frameData["all"], dims=(axis,))
-    # mask = torch.flip(frameData["mask"][0], dims=(axis,)).unsqueeze(0)
-    
+            
     psi = torch.flip(frameData["psi"], dims=(axis+1,))
     all = torch.flip(frameData["all"], dims=(axis+1,))
     mask = torch.flip(frameData["mask"], dims=(axis+1,))

--- a/XPointMLTest.py
+++ b/XPointMLTest.py
@@ -77,7 +77,8 @@ def rotate(frameData,deg):
     plotSimple(all[2], f"{frameData['fnum']}_rotation{deg}_all2.png")
     plotSimple(all[3], f"{frameData['fnum']}_rotation{deg}_all3.png")
     
-    mask = v2.functional.rotate(frameData["mask"], deg, v2.InterpolationMode.BILINEAR)
+    # mask = v2.functional.rotate(frameData["mask"], deg, v2.InterpolationMode.BILINEAR)
+    mask = v2.functional.rotate(frameData["mask"], deg, v2.InterpolationMode.NEAREST)
     return {
         "fnum": frameData["fnum"],
         "rotation": deg,
@@ -95,13 +96,21 @@ def reflect(frameData,axis):
     if axis not in [0,1]:
         print(f"invalid reflection axis specified... exiting")
         sys.exit()
-    psi = torch.flip(frameData["psi"][0], dims=(axis,)).unsqueeze(0)
-    all = torch.flip(frameData["all"], dims=(axis,))
+        
+    # psi = torch.flip(frameData["psi"][0], dims=(axis,)).unsqueeze(0)
+    # all = torch.flip(frameData["all"], dims=(axis,))
+    # mask = torch.flip(frameData["mask"][0], dims=(axis,)).unsqueeze(0)
+    
+    psi = torch.flip(frameData["psi"], dims=(axis+1,))
+    all = torch.flip(frameData["all"], dims=(axis+1,))
+    mask = torch.flip(frameData["mask"], dims=(axis+1,))
+    
     plotSimple(all[0], f"{frameData['fnum']}_reflectionAxis{axis}_all0.png")
     plotSimple(all[1], f"{frameData['fnum']}_reflectionAxis{axis}_all1.png")
     plotSimple(all[2], f"{frameData['fnum']}_reflectionAxis{axis}_all2.png")
     plotSimple(all[3], f"{frameData['fnum']}_reflectionAxis{axis}_all3.png")
-    mask = torch.flip(frameData["mask"][0], dims=(axis,)).unsqueeze(0)
+    
+    
     return {
         "fnum": frameData["fnum"],
         "rotation": 0,


### PR DESCRIPTION
This PR fixes incorrect tensor dimension handling in the reflect() function, improves mask interpolation in the rotate() function to preserve binary nature of segmentation masks, and removes redundant train_loss and val_loss declarations that reset loaded loss history.

Problems:
- reflect() function was mixing 2D and 3D tensor operations which caused incorrect flips for all tensor (containing 4 channels of physical fields).
- Using bilinear interpolation for binary masks in the rotate() function introduced intermediate values, which could corrupt the binary ground truth (i.e. instead of 0, 1, we can get 0.25, 0.75).
- Extra declaration of train_loss and val_loss resetting loss history.

Changes made:
- Changed BILINEAR to NEAREST for mask in rotate function to preserve binary values (0s and 1s only).
- Corrected reflection operations to use consistent 3D tensor dimensions by changing dims=(axis,) to dims=(axis+1,) for all tensors, fixing the incorrect dimension mapping for 3D tensors.
- Removed extra train_loss and val_loss declarations after checkpoint loading that were resetting the loaded loss history.