### PR TITLE
Fixed Overfitting with Dropout Rate, Weight Decay, and on the fly data augmentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,10 +85,12 @@ run it
 The classifier supports several command line options for training configuration:
 
 ### Training Parameters
-- `--learningRate`: Learning rate for training (default: 1e-4)
-- `--batchSize`: Batch size for training (default: 8)
-- `--epochs`: Number of training epochs (default: 100)
-- `--minTrainingLoss`: Minimum reduction in training loss in orders of magnitude (default: 2, set to 0 to disable check)
+- `--learningRate`: Learning rate for training (default: 1e-5)
+- `--weightDecay`: Weight decay for L2 regularization (default: 1e-4)
+- `--dropoutRate`: Dropout rate for regularization (default: 0.2)
+- `--batchSize`: Batch size for training (default: 1)
+- `--epochs`: Number of training epochs (default: 2000)
+- `--minTrainingLoss`: Minimum reduction in training loss in orders of magnitude (default: 3, set to 0 to disable check)
 
 ### Data Configuration
 - `--trainFrameFirst`: First frame number for training data (default: 1)
@@ -102,6 +104,8 @@ The classifier supports several command line options for training configuration:
 - `--use-amp`: Enable automatic mixed precision training for faster training on modern GPUs
 - `--amp-dtype`: Data type for mixed precision (`float16` or `bfloat16`, default: `bfloat16`)
 - `--patience`: Patience for early stopping (default: 15 epochs)
+- `--seed`: Random seed for reproducibility (default: None for non-deterministic)
+- `--require-gpu`: Require GPU to be available, exit if not found
 
 ### Output and Monitoring
 - `--plot`: Enable creation of figures showing ground truth and model-identified X-points
@@ -118,18 +122,21 @@ The classifier supports several command line options for training configuration:
 
 ### Example with Advanced Options
 
-For faster training with mixed precision and early stopping:
-
+For training with custom regularization and reproducibility:
 ```bash
 python -u ${rcRoot}/reconClassifier/XPointMLTest.py \
 --paramFile=/path/to/params.txt \
 --xptCacheDir=/path/to/cache \
 --epochs 200 \
 --learningRate 1e-4 \
+--weightDecay 1e-3 \
+--dropoutRate 0.3 \
 --batchSize 16 \
 --use-amp \
 --amp-dtype bfloat16 \
 --patience 20 \
+--seed 42 \
+--require-gpu \
 --plot \
 --trainFrameLast 100 \
 --validationFrameLast 120

--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ The classifier supports several command line options for training configuration:
 
 ### Training Parameters
 - `--learningRate`: Learning rate for training (default: 1e-5)
-- `--weightDecay`: Weight decay for L2 regularization (default: 1e-4)
-- `--dropoutRate`: Dropout rate for regularization (default: 0.2)
+- `--weightDecay`: Weight decay for L2 regularization (default: 5e-4)
+- `--dropoutRate`: Dropout rate for regularization (default: 0.3)
 - `--batchSize`: Batch size for training (default: 1)
 - `--epochs`: Number of training epochs (default: 2000)
 - `--minTrainingLoss`: Minimum reduction in training loss in orders of magnitude (default: 3, set to 0 to disable check)
@@ -110,7 +110,7 @@ The classifier supports several command line options for training configuration:
 ### Output and Monitoring
 - `--plot`: Enable creation of figures showing ground truth and model-identified X-points
 - `--plotDir`: Directory where figures are written (default: `./plots`)
-- `--checkPointFrequency`: Number of epochs between model checkpoints (default: 10)
+- `--checkPointFrequency`: Number of epochs between model checkpoints (default: 100)
 
 ### Performance Benchmarking
 - `--benchmark`: Enable performance benchmarking (tracks timing, throughput, GPU memory)

--- a/XPointMLTest.py
+++ b/XPointMLTest.py
@@ -881,7 +881,7 @@ def parseCommandLineArgs():
                         minimum reduction in training loss in orders of magnitude,
                         set to 0 to disable the check (default: 3)
                         ''')
-    parser.add_argument('--checkPointFrequency', type=int, default=10,
+    parser.add_argument('--checkPointFrequency', type=int, default=100,
                         help='number of epochs between checkpoints')
     parser.add_argument('--paramFile', type=Path, default=None,
                         help='''

--- a/XPointMLTest.py
+++ b/XPointMLTest.py
@@ -503,7 +503,7 @@ class UNet(nn.Module):
     """
     Improved U-Net with residual blocks and better normalization
     """
-    def __init__(self, input_channels=4, base_channels=32, dropout_rate=0.2):
+    def __init__(self, input_channels=4, base_channels=32, *, dropout_rate):
         super().__init__()
         
         # Encoder


### PR DESCRIPTION
# Add Regularization and Data Augmentation

This PR adds regularization techniques and on-the-fly data augmentation to improve model training.

## Changes

### New Command-Line Arguments
* `--dropoutRate` (default: 0.3) - Control dropout strength
* `--weightDecay` (default: 5e-4) - Control L2 regularization
* `--seed` (default: None) - Set random seed for reproducibility
* `--require-gpu` - Exit if GPU not available

### Dropout Improvements
* `UNet` now accepts `dropout_rate` parameter
* Added dropout layers after each decoder block (`dec1_dropout`, `dec2_dropout`, `dec3_dropout`, `dec4_dropout`)
* Added dropout after bottleneck (`bottleneck_dropout`)

### Weight Decay
* Changed from hardcoded `weight_decay=1e-5` to configurable `weight_decay=args.weightDecay`
* Logged in optimizer initialization output

### On-the-Fly Data Augmentation
* Added `augment` parameter to `XPointPatchDataset`
* Added `seed` parameter to `XPointPatchDataset` for reproducible augmentation
* New `_apply_augmentation()` method with:
  - Random rotation (90°, 180°, 270°) - 75% probability
  - Random horizontal flip - 50% probability
  - Random vertical flip - 50% probability
  - Gaussian noise injection - 30% probability
  - Brightness/contrast adjustment - 30% probability
  - Random cutout/erasing - 20% probability
* Training uses `augment=True`, validation uses `augment=False`
* Removed static augmentation: `XPointDataset(..., rotateAndReflect=False)`

### Reproducibility
* New `set_seed()` function sets seeds for Python, NumPy, and PyTorch
* Configures PyTorch deterministic mode when seed is provided
* Seeds propagated to patch datasets

### GPU Checking
* `--require-gpu` flag exits with error if CUDA unavailable
* Provides diagnostic messages for troubleshooting